### PR TITLE
Remove `drupal/devel` from `require-dev`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "drupal/config_installer": "^1.8",
         "drupal/config_split": "^1.3",
         "drupal/core": "^8.5",
+        "drupal/devel": "^1.2",
         "drupal/honeypot": "^1.27",
         "drupal/oomph_paragraphs": "^1.0",
         "drupal/recreate_block_content": "^2.0",
@@ -39,7 +40,6 @@
         "oomphinc/composer-installers-extender": "^1.1"
     },
     "require-dev": {
-        "drupal/devel": "^1.2",
         "phpunit/phpunit": "^6.5",
         "symfony/phpunit-bridge": "^4.0"
     },


### PR DESCRIPTION

<!-- Please use a meaningful pull request title -->
<!-- Please apply meaningful GitHub Labels to your pull request such as: PHP, Twig, SCSS, JS, etc. -->
## Summary
Drupal modules should always be in the `require` section, and not treated as dev dependencies even if they're a development related module.

In the past I had recommended that we put `devel` in the `require-dev` section, but that was a mistake. Since `config_split` determines what is enabled or not, having it missing depending on how you run `composer install` doesn't make sense.

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Documentation reflects changes? | n/a
| `CHANGELOG` reflects changes? | n/a
| Unit/Functional tests reflect changes? | n/a
| Risk level | Low
| Relevant links | n/a
