### PR TITLE
Add sass globbing ability to Gulp

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,6 +4,7 @@ const gulp = require('gulp');
 const rename = require('gulp-rename');
 const sass = require('gulp-sass');
 const stylelint = require('gulp-stylelint');
+const sassGlob = require('gulp-sass-glob');
 
 // Directories to search SCSS files to compile. By default, node-sass does not
 // compile files that begin with _.
@@ -38,6 +39,7 @@ gulp
   .task('build:sass', () => {
     return gulp
       .src(scssFilePaths)
+      .pipe(sassGlob())
       .pipe(sass({
         includePaths: [
           "node_modules",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "gulp-eslint": "^4.0.2",
     "gulp-rename": "^1.2.3",
     "gulp-sass": "^4.0.1",
+    "gulp-sass-glob": "^1.0.9",
     "gulp-stylelint": "^7.0.0",
     "node-sass": "^4.9.0",
     "stylelint": "^9.2.1",


### PR DESCRIPTION
<!-- Please use a meaningful pull request title -->
<!-- Please apply meaningful GitHub Labels to your pull request such as: PHP, Twig, SCSS, JS, etc. -->
## Summary
<!-- Include a summary of your changes that expands upon the title -->
Adds sass globbing ability to Gulp so that in our main sass file we can call out folder paths instead of every individual file line by line

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Documentation reflects changes? | no
| `CHANGELOG` reflects changes? | no
| Unit/Functional tests reflect changes? | no
| Risk level | Low
| Relevant links | n/a
