### PR TITLE
Remove drupal/config_installer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
         "drupal/admin_toolbar": "^1.23",
         "drupal/coder": "^8.2",
         "drupal/coffee": "^1.0",
-        "drupal/config_installer": "^1.8",
         "drupal/config_split": "^1.3",
         "drupal/core": "^8.6",
         "drupal/devel": "^1.2",


### PR DESCRIPTION
## Summary
This removes config installer profile since the ability to install a Drupal site from an existing configuration now ships with Drupal 8.6.

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | n/a
| `CHANGELOG` reflects changes? | n/a
| Unit/Functional tests reflect changes? | n/a
| Did you perform browser testing? | n/a
| Risk level | Low
| Relevant links | n/a
