### PR TITLE
Turn off xdebug in Lando by default

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -4,7 +4,7 @@ recipe: drupal8
 config:
   php: "7.2"
   webroot: web
-  xdebug: true
+  xdebug: false
 
 events:
   # Clear cache after a database import


### PR DESCRIPTION
<!-- INSTRUCTIONS
- Please use a meaningful pull request title which does not include the issue
  key or branch name.
- Please apply meaningful GitHub Labels to your pull request such as: PHP,
  Twig, SCSS, JS, etc.
- Please make sure you've reviewed the "Files changed" tab before opening this
  PR to ensure it includes what you expect (and nothing more) and adheres to
  our coding standards.
- Browser requirements can be found in docs/browser-requirements.md from the
  root of the project.
-->

## Summary
This turns off xdebug in Lando by default improving performance in docker for mac. xdebug can be enabled on a per user basis in the `.lando.local.yml` file.

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | n/a
| `CHANGELOG` reflects changes? | n/a
| Unit/Functional tests reflect changes? | n/a
| Did you perform browser testing? | n/a
| Risk level | Low
| Relevant links | n/a
