### PR TITLE
Tooling to enable / disable Xdebug.

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -44,3 +44,20 @@ tooling:
   security-check:
     service: appserver
     cmd: "php vendor/sensiolabs/security-checker/security-checker security:check composer.lock"
+
+  # Tooling to enable/disable Xdebug (see https://github.com/AaronFeledy/lando-examples/tree/master/xdebug )
+  xdebug-on:
+    service: appserver
+    description: Enable Xdebug.
+    user: root
+    cmd:
+      - docker-php-ext-enable xdebug && pkill -o -USR2 php-fpm || /etc/init.d/apache2 reload
+      - tput setaf 2 && echo "Xdebug On" && tput sgr 0 && echo
+
+  xdebug-off:
+    service: appserver
+    description: Disable Xdebug.
+    user: root
+    cmd:
+      - rm /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && pkill -o -USR2 php-fpm || /etc/init.d/apache2 reload
+      - tput setaf 1 && echo "Xdebug Off" && tput sgr 0 && echo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ## [Unreleased]
 ### Added
+Added lando xdebug-on tooling to enable Xdebug.
+Added lando xdebug-off tooling to disable Xdebug.
 
 ### Changed
 


### PR DESCRIPTION
## Summary
Use lando xdebug-on to enable Xdebug and lando xdebug-off to disable Xdebug.
Thanks to https://github.com/AaronFeledy/lando-examples/tree/master/xdebug

Note: I just learned this cool trick from Aaron Feledy at DrupalCamp Chattanooga.
I thought it would be a good addition to the Oomph drupal-scaffold, but I haven't tested it yet.

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | no
| Did you perform a self review first? | no
| Documentation reflects changes? | no
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | no
| Did you perform browser testing? | no
| Risk level | Low
| Relevant links | n/a