### PR TITLE
Remove deprecated function and generalize memcache setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Added lando xdebug-on tooling to enable Xdebug.
 Added lando xdebug-off tooling to disable Xdebug.
 
 ### Changed
+Updated memcache config in settings.php.
 
 ### Deprecated
 

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -88,6 +88,9 @@
  * ];
  * @endcode
  */
+
+use Drupal\Core\Installer\InstallerKernel;
+
 $databases = [];
 
 /**
@@ -822,9 +825,9 @@ if (getenv('LANDO_INFO')) {
   if ($memcache_module_is_present && ($memcache_exists || $memcached_exists)) {
     $settings['memcache']['servers'] = ['cache:11211' => 'default'];
     $settings['memcache']['bins'] = ['default' => 'default'];
-    $settings['memcache']['key_prefix'] = 'leicageosystems_';
+    $settings['memcache']['key_prefix'] = 'site_prefix_';
 
-    if (!drupal_installation_attempted()) {
+    if (!InstallerKernel::installationAttempted()) {
       $settings['cache']['default'] = 'cache.backend.memcache';
     }
   }

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -58,6 +58,8 @@
  * implementations with custom ones.
  */
 
+use Drupal\Core\Installer\InstallerKernel;
+
 /**
  * Database settings:
  *
@@ -88,8 +90,6 @@
  * ];
  * @endcode
  */
-
-use Drupal\Core\Installer\InstallerKernel;
 
 $databases = [];
 


### PR DESCRIPTION
<!-- INSTRUCTIONS
- Please use a meaningful pull request title which does not include the issue
  key or branch name.
- Please apply meaningful GitHub Labels to your pull request such as: PHP,
  Twig, SCSS, JS, etc.
- Please make sure you've reviewed the "Files changed" tab before opening this
  PR to ensure it includes what you expect (and nothing more) and adheres to
  our coding standards.
- Browser requirements can be found in docs/browser-requirements.md from the
  root of the project.
-->

## Summary
<!-- Include a summary of your changes that expands upon the title. -->
Fixes the deprecated d8 function with the d9 version (see link)
Replaces site specific memcache prefix config with a generic one.

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | no
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | no
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | https://api.drupal.org/api/drupal/core%21includes%21bootstrap.inc/function/drupal_installation_attempted/8.9.x